### PR TITLE
Fixe LOAD_CHAR_INFO and LOAD_USER_DATA procedures

### DIFF
--- a/src/migration/5_alter_load_char_info_procedure.sql
+++ b/src/migration/5_alter_load_char_info_procedure.sql
@@ -1,0 +1,22 @@
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- Scripted by Samma
+-- 2002.01.18
+
+ALTER PROCEDURE [dbo].[LOAD_CHAR_INFO]
+@CharId	char(21),
+@nRet		smallint OUTPUT
+AS
+
+SELECT @nRet = COUNT(strUserId) FROM USERDATA WHERE strUserId = @CharId
+IF @nRet = 0
+	RETURN
+
+SELECT Race, Class, HairColor, [Level], Face, Zone, strItem FROM USERDATA WHERE strUserID = @CharId
+
+SET @nRet = 1
+RETURN
+
+GO

--- a/src/migration/6_alter_load_user_data_procedure.sql
+++ b/src/migration/6_alter_load_user_data_procedure.sql
@@ -1,0 +1,25 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+
+ALTER PROCEDURE [dbo].[LOAD_USER_DATA]
+@id	char(21),
+@nRet smallint OUTPUT
+AS
+
+SET @nRet = 0
+
+SELECT @nRet = COUNT(strUserId) FROM USERDATA WHERE strUserId = @id
+IF @nRet = 0
+	RETURN
+
+SELECT Nation, Race, Class, HairColor, Rank, Title, [Level], [Exp], Loyalty, Face, City, Knights, Fame, 
+	 Hp, Mp, Sp, Strong, Sta, Dex, Intel, Cha, Authority, Points, Gold, [Zone], Bind, PX, PZ, PY, dwTime, strSkill, strItem,strSerial
+FROM	USERDATA WHERE strUserId = @id
+
+SET @nRet = 1
+RETURN
+
+GO


### PR DESCRIPTION
### Description

Note that because there was no proper usage of OUTPUT as return type,
the server failed to process this procedure.
