### PR TITLE
Update NATION_SELECT.sql

### DIFF
--- a/src/migration/7_alter_nation_select_procedure.sql
+++ b/src/migration/7_alter_nation_select_procedure.sql
@@ -1,0 +1,35 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+ALTER PROCEDURE [dbo].[NATION_SELECT]
+@nRet		smallint	OUTPUT,
+@AccountID 	char(21),
+@Nation	tinyint
+AS
+
+DECLARE @Row tinyint, @CharNum smallint
+SET @Row = 0
+
+BEGIN TRAN	
+
+	SELECT @Row = COUNT(*) FROM  ACCOUNT_CHAR  WHERE strAccountID = @AccountID
+	IF @Row > 0
+		UPDATE ACCOUNT_CHAR SET bNation = @Nation WHERE strAccountID = @AccountID
+	ELSE
+		INSERT INTO ACCOUNT_CHAR (strAccountID, bNation ) VALUES (@AccountID, @Nation)
+
+	SELECT @Row = COUNT(*) FROM  WAREHOUSE  WHERE strAccountID = @AccountID
+	IF @Row = 0	
+		INSERT INTO WAREHOUSE ( strAccountID ) VALUES (@AccountID)
+
+	IF @@ERROR <> 0
+	BEGIN	 
+		ROLLBACK TRAN 
+		SET @nRet =  -2	
+		RETURN
+	END
+	
+COMMIT TRAN
+SET @nRet =  1

--- a/src/procedure/NATION_SELECT.sql
+++ b/src/procedure/NATION_SELECT.sql
@@ -9,7 +9,14 @@ CREATE PROCEDURE [dbo].[NATION_SELECT]
 AS
 
 DECLARE @Row tinyint
-SET @Row = 0
+	SET @Row = 0
+
+	SELECT @Row = COUNT(*) FROM  ACCOUNT_CHAR  WHERE strAccountID = @AccountID
+	IF @Row > 0	
+	BEGIN
+		SET @nRet = -1
+		RETURN
+	END
 
 BEGIN TRAN	
 

--- a/src/procedure/NATION_SELECT.sql
+++ b/src/procedure/NATION_SELECT.sql
@@ -9,14 +9,7 @@ CREATE PROCEDURE [dbo].[NATION_SELECT]
 AS
 
 DECLARE @Row tinyint
-	SET @Row = 0
-
-	SELECT @Row = COUNT(*) FROM  ACCOUNT_CHAR  WHERE strAccountID = @AccountID
-	IF @Row > 0	
-	BEGIN
-		SET @nRet = -1
-		RETURN
-	END
+SET @Row = 0
 
 BEGIN TRAN	
 


### PR DESCRIPTION
OK, here is the problem I see with the nation select screen:
1. The database starts with a row in the ACCOUNT_CHAR table for the steve account but bCharNum=0
2. CDBAgent::AccountLogInReq calls the stored procedure CHAR_SELECT to check whether bCharNum=0 or if there are no rows in the ACCOUNT_CHAR table for the account
3. Based on how the DB is initially setup bCharNum=0 for the steve account and therefore, by default, it takes the player to the nation select screen.
4. However, the WIZ_SEL_NATION packet calls the [NATION_SELECT] stored procedure and that stored procedure will only let the player pick a nation if the number of rows in the ACCOUNT_CHAR table for that account is 0

Therefore the check is coded differently for the CHAR_SELECT procedure and the NATION_SELECT procedure. I suggest making the check in the NATION_SELECT procedure align with the check in the CHAR_SELECT procedure and allow either bCharNum=0 or the number of rows in the ACCOUNT_CHAR table to be zero. Instead of just checking the ACCOUNT_CHAR table.

If you look at the code that follows it is handling both situations when the number of rows is > 0 and = 0
, so I don't think it is needed and it opens players up to soft locking their accounts by selecting a nation and then closing the game before they create a character.