### PR TITLE
Fix scripts to adapt MSSQL Server 2022 breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ During development we only create migration scripts to alter the current state o
 
 Every migration script will be prefixed by index. For example, `1_insert_steve_user.sql` will contain an insert statement to `TB_USER` table.
 
+Apart from the benifit of having the database under version control, this also makes it easy to use any SQL version you want. I use both 2008 and 2022 and it works perfectly fine with both.
+
 Release process should follow for every release we create in the [main ko project](https://github.com/ko4life-net/ko). The steps should look like this:
 - Main ko project needs a new release
   - Are there any pending migration scrips in the ko-db project?

--- a/export.ps1
+++ b/export.ps1
@@ -13,12 +13,14 @@ param (
     $db_name = "kodb"
 )
 
+. "$PSScriptRoot\logger.ps1"
+
 function Main {
   # Check if mssql-scripter command is available
   if (-not (Get-Command mssql-scripter -ErrorAction SilentlyContinue)) {
-    Write-Host "Error: 'mssql-scripter' command is not available."  -ForegroundColor Red
-    Write-Host "Please make sure you have Python installed and then run:"  -ForegroundColor Red
-    Write-Host "pip install mssql-scripter" -ForegroundColor Red
+    MessageError "Error: 'mssql-scripter' command is not available."  -ForegroundColor Red
+    MessageError "Please make sure you have Python installed and then run:"  -ForegroundColor Red
+    MessageError "pip install mssql-scripter" -ForegroundColor Red
     exit 1
   }
 
@@ -61,6 +63,8 @@ function Main {
   }
 
   Remove-Item tmp -Recurse
+
+  MessageSuccess "Successfully exported [$db_name] database from [$server_name] SQL server."
 }
 
 Main

--- a/logger.ps1
+++ b/logger.ps1
@@ -1,0 +1,25 @@
+# Simple and colorful log messages
+function Message {
+  param ([string][Parameter(Mandatory)] $message)
+  Write-Host "$message" -ForegroundColor White
+}
+
+function MessageInfo {
+  param ([string][Parameter(Mandatory)] $message)
+  Write-Host "$message" -ForegroundColor Blue
+}
+
+function MessageSuccess {
+  param ([string][Parameter(Mandatory)] $message)
+  Write-Host "$message" -ForegroundColor Green
+}
+
+function MessageWarn {
+  param ([string][Parameter(Mandatory)] $message)
+  Write-Host "$message" -ForegroundColor Yellow
+}
+
+function MessageError {
+  param ([string][Parameter(Mandatory)] $message)
+  Write-Host "$message" -ForegroundColor Red
+}

--- a/src/misc/backup_db.sql
+++ b/src/misc/backup_db.sql
@@ -1,0 +1,42 @@
+USE master;
+GO
+
+IF OBJECT_ID('N3BackupDatabase', 'P') IS NOT NULL
+BEGIN
+    DROP PROCEDURE N3BackupDatabase;
+END
+GO
+
+CREATE PROCEDURE N3BackupDatabase
+    @DatabaseName NVARCHAR(128),
+    @BackupFilePath NVARCHAR(260)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @SQL NVARCHAR(MAX);
+
+    -- Check if the database exists
+    IF EXISTS (SELECT 1 FROM sys.databases WHERE name = @DatabaseName)
+    BEGIN
+        -- Construct the dynamic SQL for backup
+        -- WITH INIT, FORMAT - Ensure we start a fresh backup file, even if the destination file exists
+        -- SKIP - in case the target db is offline
+        -- NOREWIND & NOREWIND - ensure no interruption to the db during the backup operation
+        -- STATS = 10 - report to us the progress for every 10% of the backup operation
+        SET @SQL = 'BACKUP DATABASE ' + QUOTENAME(@DatabaseName) +
+                   ' TO DISK = ' + QUOTENAME(@BackupFilePath, '''') +
+                   ' WITH INIT, FORMAT, NAME = N''' + @DatabaseName + ' Backup'', ' +
+                   ' SKIP, NOREWIND, NOUNLOAD, STATS = 10';
+
+        -- Execute the backup command
+        PRINT 'Query: [' + @SQL + ']';
+        EXEC sp_executesql @SQL;
+
+        PRINT 'Backup of database [' + @DatabaseName + '] completed successfully.';
+    END
+    ELSE
+    BEGIN
+        PRINT 'Database [' + @DatabaseName + '] does not exist. Backup operation aborted.';
+    END
+END


### PR DESCRIPTION
### Description

Note that with MSSQL Server 2022 new security features were added and it is enforced by default to enable encryption to prevent man-in-the-middle attacks. However since we use these scripts for local development, these security features are irrelevant for us and does not worth to efforts in setting up a certificate and such.

Due to the new changes, this also breaks some parts of our scripts where it communicates with the database. Therefore we changed our approach to enforce every query to trust the certificate and disable encryption.

That is also why I changed the way we create backup to use a stored procedure instead, since the previous method no longer works using the dotnet modules.

+ Add colored messages.
+ Change the approach for creating database backups.
+ Change the approach of sending queries to the db from a centralized
  function.