### PR TITLE
Fix inconsistent case sensitivity issues

### DIFF
--- a/src/migration/18_fix_case_sensitivity_errors.sql
+++ b/src/migration/18_fix_case_sensitivity_errors.sql
@@ -1,0 +1,422 @@
+-- Fixes an issue with some dbs that their default installation collation is case-sensitive (_CS).
+-- Also note that we found out about this issue because of some user using Turkish_CI_AS collation and after changing
+-- the all @KnightsIndex instances to use the same case-sensitivity, the problem was fixed. However twostars figured out
+-- that the actual cause of this issue is when using `i` in a db that has Turkish collation, because in Turkish `i` is not
+-- `I`, hence it didn't see them as the same variables (declaration and usages), even when the user collation was case-insensitive (_CI).
+-- twostars actually tested this on a VM with the same setup to verify, since this was indeed an odd issue.
+--
+-- Altered procedures:
+--   - CHECK_KNIGHTS
+--   - DELETE_CHAR
+--   - EDITER_KNIGHTS
+--   - EXEC_KNIGHTS_USER
+--   - LOAD_CHAR_INFO
+
+--------------------------------------------------------------------------------------------------
+-- CHECK_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER PROCEDURE [dbo].[CHECK_KNIGHTS]
+AS
+
+SET NOCOUNT ON
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT IDNum FROM KNIGHTS
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @KnightsIndex
+WHILE @@fetch_status = 0
+  BEGIN
+    DECLARE @ROW int
+
+    SELECT @ROW = Members FROM [KNIGHTS] WHERE [IDNum] = @KnightsIndex
+    IF @ROW = 1
+      BEGIN
+        BEGIN TRAN
+        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+
+        IF @@ERROR != 0
+          BEGIN
+            ROLLBACK TRAN
+          END
+        ELSE
+          BEGIN
+            UPDATE USERDATA SET Knights = 0, Fame = 0 WHERE Knights = @KnightsIndex
+            DELETE FROM KNIGHTS_USER WHERE [sIDNum] = @KnightsIndex
+          END
+        COMMIT TRAN
+      END
+
+    FETCH NEXT FROM job1
+    INTO @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- DELETE_CHAR
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+ALTER PROCEDURE [dbo].[DELETE_CHAR]
+  @AccountID char(21),
+  @index tinyint,
+  @CharID char(21),
+  @SocNo char(15),
+  @nRet smallint OUTPUT
+AS
+
+DECLARE
+  @bCharNum tinyint,
+  @charid1 char(21),
+  @charid2 char(21),
+  @charid3 char(21),
+  @charid4 char(21),
+  @charid5 char(21),
+  @strSocNo char(15)
+DECLARE @knightsindex smallint
+SET @bCharNum = 0
+SET @knightsindex = 0
+
+SELECT @strSocNo = strSocNo FROM [dbo].[TB_USER] WHERE strAccountID = @AccountID
+IF @SocNo != @strSocNo
+  BEGIN
+    SET @nRet = 0
+    RETURN
+  END
+
+DECLARE
+  @Nation tinyint,
+  @Race tinyint,
+  @Class smallint,
+  @HairColor tinyint,
+  @Rank tinyint,
+  @Title tinyint,
+  @Level tinyint,
+  @Exp int,
+  @Loyalty int
+DECLARE
+  @Face tinyint,
+  @City tinyint,
+  @Knights smallint,
+  @Fame tinyint,
+  @Hp smallint,
+  @Mp smallint,
+  @Sp smallint,
+  @Strong tinyint,
+  @Sta tinyint,
+  @Dex tinyint
+DECLARE
+  @Intel tinyint,
+  @Cha tinyint,
+  @Authority tinyint,
+  @Points tinyint,
+  @Gold int,
+  @Zone tinyint,
+  @Bind smallint,
+  @PX int,
+  @PZ int,
+  @PY int,
+  @dwTime int
+DECLARE @bySkill binary(10), @byItem binary(400), @bySerial binary(400), @Members smallint
+
+BEGIN TRAN
+
+IF @index = 0
+  UPDATE ACCOUNT_CHAR SET strCharID1 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 1
+  UPDATE ACCOUNT_CHAR SET strCharID2 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 2
+  UPDATE ACCOUNT_CHAR SET strCharID3 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 3
+  UPDATE ACCOUNT_CHAR SET strCharID4 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 4
+  UPDATE ACCOUNT_CHAR SET strCharID5 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 0
+    RETURN
+  END
+
+SELECT
+  @charid1 = strCharID1,
+  @charid2 = strCharID2,
+  @charid3 = strCharID3,
+  @charid4 = strCharID4,
+  @charid5 = strCharID5
+FROM ACCOUNT_CHAR
+WHERE strAccountID = @AccountID
+-- 캐릭터가 하나도 없으면 해당 레코드를 지운다.. -> 국가선택 다시 할수 있다
+IF @charid1 IS NULL AND @charid2 IS NULL AND @charid3 IS NULL AND @charid4 IS NULL AND @charid5 IS NULL
+  BEGIN
+    DELETE FROM ACCOUNT_CHAR WHERE strAccountID = @AccountID
+    IF @@ERROR != 0
+      BEGIN
+        ROLLBACK TRAN
+        SET @nRet = 0
+        RETURN
+      END
+  END
+
+SELECT
+  @Nation = Nation,
+  @Race = Race,
+  @Class = [Class],
+  @HairColor = HairColor,
+  @Rank = Rank,
+  @Title = Title,
+  @Level = [Level],
+  @Exp = [Exp],
+  @Loyalty = Loyalty,
+  @Face = Face,
+  @City = City,
+  @Knights = Knights,
+  @Fame = Fame,
+  @Hp = Hp,
+  @Mp = Mp,
+  @Sp = Sp,
+  @Strong = Strong,
+  @Sta = Sta,
+  @Dex = Dex,
+  @Intel = Intel,
+  @Cha = Cha,
+  @Authority = Authority,
+  @Points = Points,
+  @Gold = Gold,
+  @Zone = [Zone],
+  @Bind = Bind,
+  @PX = PX,
+  @PZ = PZ,
+  @PY = PY,
+  @dwTime = dwTime,
+  @bySkill = bySkill,
+  @byItem = byItem,
+  @bySerial = bySerial
+FROM USERDATA WHERE strUserId = @CharID
+
+INSERT INTO DELETED_USERDATA (
+  strAccountID,
+  strUserId,
+  Nation,
+  Race,
+  [Class],
+  HairColor,
+  Rank,
+  Title,
+  [Level],
+  [Exp],
+  Loyalty,
+  Face,
+  City,
+  Knights,
+  Fame,
+  Hp,
+  Mp,
+  Sp,
+  Strong,
+  Sta,
+  Dex,
+  Intel,
+  Cha,
+  Authority,
+  Points,
+  Gold,
+  [Zone],
+  Bind,
+  PX,
+  PZ,
+  PY,
+  dwTime,
+  bySkill,
+  byItem,
+  bySerial
+)
+VALUES (
+  @AccountID,
+  @CharID,
+  @Nation,
+  @Race,
+  @Class,
+  @HairColor,
+  @Rank,
+  @Title,
+  @Level,
+  @Exp,
+  @Loyalty,
+  @Face,
+  @City,
+  @Knights,
+  @Fame,
+  @Hp,
+  @Mp,
+  @Sp,
+  @Strong,
+  @Sta,
+  @Dex,
+  @Intel,
+  @Cha,
+  @Authority,
+  @Points,
+  @Gold,
+  @Zone,
+  @Bind,
+  @PX,
+  @PZ,
+  @PY,
+  @dwTime,
+  @bySkill,
+  @byItem,
+  @bySerial
+)
+
+DELETE FROM USERDATA WHERE strUserId = @CharID
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 0
+    RETURN
+  END
+
+DELETE FROM KNIGHTS_USER WHERE strUserID = @CharID
+SELECT @Members = Members FROM KNIGHTS WHERE IDNum = @Knights
+IF @Members <= 1
+  UPDATE KNIGHTS SET Members = 1 WHERE IDNum = @Knights
+ELSE
+  UPDATE KNIGHTS SET Members = Members - 1 WHERE IDNum = @Knights
+
+COMMIT TRAN
+SET @nRet = 1
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- EDITER_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- Create sungyong
+
+ALTER PROCEDURE [dbo].[EDITER_KNIGHTS]
+AS
+
+SET NOCOUNT ON
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT IDNum FROM KNIGHTS
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @KnightsIndex
+WHILE @@fetch_status = 0
+  BEGIN
+    DECLARE @LEVEL int
+    DECLARE @ROW int
+    SET @LEVEL = 0
+
+    SELECT @ROW = COUNT([strUserId]) FROM [USERDATA] WHERE Knights = @KnightsIndex
+    IF @ROW != 0
+      BEGIN
+        UPDATE KNIGHTS SET [Members] = @Row WHERE IDNum = @KnightsIndex
+      END
+    ELSE
+      BEGIN
+        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+      END
+
+    FETCH NEXT FROM job1
+    INTO @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- EXEC_KNIGHTS_USER
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- create by sungyong 2002.09.16
+
+ALTER PROCEDURE [dbo].[EXEC_KNIGHTS_USER]
+AS
+
+SET NOCOUNT ON
+DECLARE @strUserId char(21)
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT
+  strUserId,
+  Knights
+FROM USERDATA
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @strUserId, @KnightsIndex
+WHILE @@fetch_status = 0
+  BEGIN
+    IF @KnightsIndex != 0
+      BEGIN
+        INSERT INTO KNIGHTS_USER (sIDNum, strUserID) VALUES (@KnightsIndex, @strUserId)
+      END
+
+    FETCH NEXT FROM job1
+    INTO @strUserId, @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- LOAD_CHAR_INFO
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- Scripted by Samma
+-- 2002.01.18
+
+ALTER PROCEDURE [dbo].[LOAD_CHAR_INFO]
+  @CharId char(21),
+  @nRet smallint OUTPUT
+AS
+
+SELECT @nRet = COUNT(strUserId) FROM USERDATA WHERE strUserId = @CharId
+IF @nRet = 0
+  RETURN
+
+  SELECT
+    Race,
+    [Class],
+    HairColor,
+    [Level],
+    Face,
+    Zone,
+    byItem
+  FROM USERDATA WHERE strUserId = @CharId
+
+SET @nRet = 1
+RETURN
+
+GO

--- a/src/migration/18_fix_case_sensitivity_errors.sql.diff
+++ b/src/migration/18_fix_case_sensitivity_errors.sql.diff
@@ -1,0 +1,145 @@
+diff --git a/src/procedure/CHECK_KNIGHTS.sql b/src/procedure/CHECK_KNIGHTS.sql
+index 127d07e..0aa8e87 100644
+--- a/src/procedure/CHECK_KNIGHTS.sql
++++ b/src/procedure/CHECK_KNIGHTS.sql
+@@ -23,7 +23,7 @@ WHILE @@fetch_status = 0
+     IF @ROW = 1
+       BEGIN
+         BEGIN TRAN
+-        DELETE FROM KNIGHTS WHERE IDNum = @knightsindex
++        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+ 
+         IF @@ERROR != 0
+           BEGIN
+@@ -31,7 +31,7 @@ WHILE @@fetch_status = 0
+           END
+         ELSE
+           BEGIN
+-            UPDATE USERDATA SET Knights = 0, Fame = 0 WHERE Knights = @knightsindex
++            UPDATE USERDATA SET Knights = 0, Fame = 0 WHERE Knights = @KnightsIndex
+             DELETE FROM KNIGHTS_USER WHERE [sIDNum] = @KnightsIndex
+           END
+         COMMIT TRAN
+diff --git a/src/procedure/DELETE_CHAR.sql b/src/procedure/DELETE_CHAR.sql
+index 59b29c6..45b8554 100644
+--- a/src/procedure/DELETE_CHAR.sql
++++ b/src/procedure/DELETE_CHAR.sql
+@@ -67,15 +67,15 @@ DECLARE @bySkill binary(10), @byItem binary(400), @bySerial binary(400), @Member
+ BEGIN TRAN
+ 
+ IF @index = 0
+-  UPDATE ACCOUNT_CHAR SET strCHARID1 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
++  UPDATE ACCOUNT_CHAR SET strCharID1 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+ IF @index = 1
+-  UPDATE ACCOUNT_CHAR SET strCHARID2 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
++  UPDATE ACCOUNT_CHAR SET strCharID2 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+ IF @index = 2
+-  UPDATE ACCOUNT_CHAR SET strCHARID3 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
++  UPDATE ACCOUNT_CHAR SET strCharID3 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+ IF @index = 3
+-  UPDATE ACCOUNT_CHAR SET strCHARID4 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
++  UPDATE ACCOUNT_CHAR SET strCharID4 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+ IF @index = 4
+-  UPDATE ACCOUNT_CHAR SET strCHARID5 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
++  UPDATE ACCOUNT_CHAR SET strCharID5 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+ 
+ IF @@ERROR != 0
+   BEGIN
+@@ -85,11 +85,11 @@ IF @@ERROR != 0
+   END
+ 
+ SELECT
+-  @charid1 = strCHARID1,
+-  @charid2 = strCHARID2,
+-  @charid3 = strCHARID3,
+-  @charid4 = strCHARID4,
+-  @charid5 = strCHARID5
++  @charid1 = strCharID1,
++  @charid2 = strCharID2,
++  @charid3 = strCharID3,
++  @charid4 = strCharID4,
++  @charid5 = strCharID5
+ FROM ACCOUNT_CHAR
+ WHERE strAccountID = @AccountID
+ -- 캐릭터가 하나도 없으면 해당 레코드를 지운다.. -> 국가선택 다시 할수 있다
+@@ -142,7 +142,7 @@ FROM USERDATA WHERE strUserId = @CharID
+ 
+ INSERT INTO DELETED_USERDATA (
+   strAccountID,
+-  strUserID,
++  strUserId,
+   Nation,
+   Race,
+   [Class],
+@@ -223,7 +223,7 @@ IF @@ERROR != 0
+     RETURN
+   END
+ 
+-DELETE FROM KNIGHTS_USER WHERE strUserId = @CharID
++DELETE FROM KNIGHTS_USER WHERE strUserID = @CharID
+ SELECT @Members = Members FROM KNIGHTS WHERE IDNum = @Knights
+ IF @Members <= 1
+   UPDATE KNIGHTS SET Members = 1 WHERE IDNum = @Knights
+diff --git a/src/procedure/EDITER_KNIGHTS.sql b/src/procedure/EDITER_KNIGHTS.sql
+index 95c6324..47591fa 100644
+--- a/src/procedure/EDITER_KNIGHTS.sql
++++ b/src/procedure/EDITER_KNIGHTS.sql
+@@ -30,7 +30,7 @@ WHILE @@fetch_status = 0
+       END
+     ELSE
+       BEGIN
+-        DELETE FROM KNIGHTS WHERE IDNum = @knightsindex
++        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+       END
+ 
+     FETCH NEXT FROM job1
+diff --git a/src/procedure/EXEC_KNIGHTS_USER.sql b/src/procedure/EXEC_KNIGHTS_USER.sql
+index ba48468..36bd632 100644
+--- a/src/procedure/EXEC_KNIGHTS_USER.sql
++++ b/src/procedure/EXEC_KNIGHTS_USER.sql
+@@ -9,27 +9,27 @@ CREATE PROCEDURE [dbo].[EXEC_KNIGHTS_USER]
+ AS
+ 
+ SET NOCOUNT ON
+-DECLARE @strUserID char(21)
++DECLARE @strUserId char(21)
+ DECLARE @KnightsIndex smallint
+ DECLARE job1 CURSOR FOR
+ 
+ SELECT
+-  strUserID,
++  strUserId,
+   Knights
+ FROM USERDATA
+ 
+ OPEN job1
+ FETCH NEXT FROM job1
+-INTO @strUserID, @KnightsIndex
++INTO @strUserId, @KnightsIndex
+ WHILE @@fetch_status = 0
+   BEGIN
+     IF @KnightsIndex != 0
+       BEGIN
+-        INSERT INTO KNIGHTS_USER (sIDNum, strUserID) VALUES (@KnightsIndex, @strUserID)
++        INSERT INTO KNIGHTS_USER (sIDNum, strUserID) VALUES (@KnightsIndex, @strUserId)
+       END
+ 
+     FETCH NEXT FROM job1
+-    INTO @strUserID, @KnightsIndex
++    INTO @strUserId, @KnightsIndex
+   END
+ CLOSE job1
+ DEALLOCATE job1
+diff --git a/src/procedure/LOAD_CHAR_INFO.sql b/src/procedure/LOAD_CHAR_INFO.sql
+index 6e70027..5e4f795 100644
+--- a/src/procedure/LOAD_CHAR_INFO.sql
++++ b/src/procedure/LOAD_CHAR_INFO.sql
+@@ -22,7 +22,7 @@ IF @nRet = 0
+     Face,
+     Zone,
+     byItem
+-  FROM USERDATA WHERE strUserID = @CharId
++  FROM USERDATA WHERE strUserId = @CharId
+ 
+ SET @nRet = 1
+ RETURN

--- a/src/migration/19_uppercase_fetch_status_usages.sql
+++ b/src/migration/19_uppercase_fetch_status_usages.sql
@@ -1,0 +1,202 @@
+-- Alter procedures to uppercase all @@fetch_status usages.
+--
+-- Altered procedures:
+--   - CHECK_KNIGHTS
+--   - EDITER_KNIGHTS
+--   - EXEC_KNIGHTS_USER
+--   - RANK_KNIGHTS
+
+--------------------------------------------------------------------------------------------------
+-- CHECK_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER PROCEDURE [dbo].[CHECK_KNIGHTS]
+AS
+
+SET NOCOUNT ON
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT IDNum FROM KNIGHTS
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @KnightsIndex
+WHILE @@FETCH_STATUS = 0
+  BEGIN
+    DECLARE @ROW int
+
+    SELECT @ROW = Members FROM [KNIGHTS] WHERE [IDNum] = @KnightsIndex
+    IF @ROW = 1
+      BEGIN
+        BEGIN TRAN
+        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+
+        IF @@ERROR != 0
+          BEGIN
+            ROLLBACK TRAN
+          END
+        ELSE
+          BEGIN
+            UPDATE USERDATA SET Knights = 0, Fame = 0 WHERE Knights = @KnightsIndex
+            DELETE FROM KNIGHTS_USER WHERE [sIDNum] = @KnightsIndex
+          END
+        COMMIT TRAN
+      END
+
+    FETCH NEXT FROM job1
+    INTO @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- EDITER_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- Create sungyong
+
+ALTER PROCEDURE [dbo].[EDITER_KNIGHTS]
+AS
+
+SET NOCOUNT ON
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT IDNum FROM KNIGHTS
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @KnightsIndex
+WHILE @@FETCH_STATUS = 0
+  BEGIN
+    DECLARE @LEVEL int
+    DECLARE @ROW int
+    SET @LEVEL = 0
+
+    SELECT @ROW = COUNT([strUserId]) FROM [USERDATA] WHERE Knights = @KnightsIndex
+    IF @ROW != 0
+      BEGIN
+        UPDATE KNIGHTS SET [Members] = @Row WHERE IDNum = @KnightsIndex
+      END
+    ELSE
+      BEGIN
+        DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+      END
+
+    FETCH NEXT FROM job1
+    INTO @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- EXEC_KNIGHTS_USER
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- create by sungyong 2002.09.16
+
+ALTER PROCEDURE [dbo].[EXEC_KNIGHTS_USER]
+AS
+
+SET NOCOUNT ON
+DECLARE @strUserId char(21)
+DECLARE @KnightsIndex smallint
+DECLARE job1 CURSOR FOR
+
+SELECT
+  strUserId,
+  Knights
+FROM USERDATA
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @strUserId, @KnightsIndex
+WHILE @@FETCH_STATUS = 0
+  BEGIN
+    IF @KnightsIndex != 0
+      BEGIN
+        INSERT INTO KNIGHTS_USER (sIDNum, strUserID) VALUES (@KnightsIndex, @strUserId)
+      END
+
+    FETCH NEXT FROM job1
+    INTO @strUserId, @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- RANK_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [dbo].[RANK_KNIGHTS]
+AS
+
+UPDATE KNIGHTS SET Points = 0
+
+SET NOCOUNT ON
+DECLARE @KnightsIndex smallint
+DECLARE @SumLoyalty int
+DECLARE job1 CURSOR FOR
+
+SELECT IDNum FROM KNIGHTS
+
+OPEN job1
+FETCH NEXT FROM job1
+INTO @KnightsIndex
+WHILE @@FETCH_STATUS = 0
+  BEGIN
+
+    SET @SumLoyalty = 0
+    SELECT @SumLoyalty = SUM(Loyalty) FROM USERDATA WHERE Knights = @Knightsindex
+    IF @SumLoyalty != 0
+      UPDATE KNIGHTS SET Points = @SumLoyalty WHERE IDNum = @knightsindex
+
+    FETCH NEXT FROM job1
+    INTO @KnightsIndex
+  END
+CLOSE job1
+DEALLOCATE job1
+SET NOCOUNT OFF
+
+EXEC KNIGHTS_RATING_UPDATE
+
+DECLARE @Knights_1 smallint
+DECLARE @Knights_2 smallint
+DECLARE @Knights_3 smallint
+DECLARE @Knights_4 smallint
+DECLARE @Knights_5 smallint
+
+SELECT @Knights_1 = shIndex FROM KNIGHTS_RATING WHERE nRank = 1
+SELECT @Knights_2 = shIndex FROM KNIGHTS_RATING WHERE nRank = 2
+SELECT @Knights_3 = shIndex FROM KNIGHTS_RATING WHERE nRank = 3
+SELECT @Knights_4 = shIndex FROM KNIGHTS_RATING WHERE nRank = 4
+SELECT @Knights_5 = shIndex FROM KNIGHTS_RATING WHERE nRank = 5
+
+UPDATE KNIGHTS SET Ranking = 1 WHERE IDNum = @Knights_1
+UPDATE KNIGHTS SET Ranking = 2 WHERE IDNum = @Knights_2
+UPDATE KNIGHTS SET Ranking = 3 WHERE IDNum = @Knights_3
+UPDATE KNIGHTS SET Ranking = 4 WHERE IDNum = @Knights_4
+UPDATE KNIGHTS SET Ranking = 5 WHERE IDNum = @Knights_5
+
+GO

--- a/src/migration/19_uppercase_fetch_status_usages.sql.diff
+++ b/src/migration/19_uppercase_fetch_status_usages.sql.diff
@@ -1,0 +1,52 @@
+diff --git a/src/procedure/CHECK_KNIGHTS.sql b/src/procedure/CHECK_KNIGHTS.sql
+index 0aa8e87..17b848e 100644
+--- a/src/procedure/CHECK_KNIGHTS.sql
++++ b/src/procedure/CHECK_KNIGHTS.sql
+@@ -15,7 +15,7 @@ SELECT IDNum FROM KNIGHTS
+ OPEN job1
+ FETCH NEXT FROM job1
+ INTO @KnightsIndex
+-WHILE @@fetch_status = 0
++WHILE @@FETCH_STATUS = 0
+   BEGIN
+     DECLARE @ROW int
+ 
+diff --git a/src/procedure/EDITER_KNIGHTS.sql b/src/procedure/EDITER_KNIGHTS.sql
+index 47591fa..8e39e78 100644
+--- a/src/procedure/EDITER_KNIGHTS.sql
++++ b/src/procedure/EDITER_KNIGHTS.sql
+@@ -17,7 +17,7 @@ SELECT IDNum FROM KNIGHTS
+ OPEN job1
+ FETCH NEXT FROM job1
+ INTO @KnightsIndex
+-WHILE @@fetch_status = 0
++WHILE @@FETCH_STATUS = 0
+   BEGIN
+     DECLARE @LEVEL int
+     DECLARE @ROW int
+diff --git a/src/procedure/EXEC_KNIGHTS_USER.sql b/src/procedure/EXEC_KNIGHTS_USER.sql
+index 36bd632..9ec3ecf 100644
+--- a/src/procedure/EXEC_KNIGHTS_USER.sql
++++ b/src/procedure/EXEC_KNIGHTS_USER.sql
+@@ -21,7 +21,7 @@ FROM USERDATA
+ OPEN job1
+ FETCH NEXT FROM job1
+ INTO @strUserId, @KnightsIndex
+-WHILE @@fetch_status = 0
++WHILE @@FETCH_STATUS = 0
+   BEGIN
+     IF @KnightsIndex != 0
+       BEGIN
+diff --git a/src/procedure/RANK_KNIGHTS.sql b/src/procedure/RANK_KNIGHTS.sql
+index 019388f..77f8fc1 100644
+--- a/src/procedure/RANK_KNIGHTS.sql
++++ b/src/procedure/RANK_KNIGHTS.sql
+@@ -17,7 +17,7 @@ SELECT IDNum FROM KNIGHTS
+ OPEN job1
+ FETCH NEXT FROM job1
+ INTO @KnightsIndex
+-WHILE @@fetch_status = 0
++WHILE @@FETCH_STATUS = 0
+   BEGIN
+ 
+     SET @SumLoyalty = 0

--- a/src/migration/20_drop_create_knights2_procedure.sql
+++ b/src/migration/20_drop_create_knights2_procedure.sql
@@ -1,0 +1,2 @@
+-- Seems like an experimental procedure that we don't want to maintain.
+DROP PROCEDURE CREATE_KNIGHTS2;

--- a/src/migration/20_drop_create_knights2_procedure.sql.diff
+++ b/src/migration/20_drop_create_knights2_procedure.sql.diff
@@ -1,0 +1,59 @@
+diff --git a/src/procedure/CREATE_KNIGHTS2.sql b/src/procedure/CREATE_KNIGHTS2.sql
+deleted file mode 100644
+index e99f8dc..0000000
+--- a/src/procedure/CREATE_KNIGHTS2.sql
++++ /dev/null
+@@ -1,53 +0,0 @@
+-﻿SET ANSI_NULLS OFF
+-GO
+-SET QUOTED_IDENTIFIER OFF
+-GO
+-
+-
+-CREATE PROCEDURE [dbo].[CREATE_KNIGHTS2]
+-
+-  @nRet smallint OUTPUT,
+-  @index smallint OUTPUT,
+-  @nation tinyint,
+-  @community tinyint,
+-  @strName char(21),
+-  @strChief char(21)
+-
+-AS
+-
+-DECLARE @Row tinyint, @knightsindex smallint, @knightsname char(21)
+-SET @Row = 0 SET @knightsindex = 0 SET @knightsname = ''
+-
+-SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @index
+-
+-IF @Row > 0 OR @index = 0
+-  BEGIN
+-    SET @nRet = 1
+-    RETURN
+-  END
+-
+-BEGIN TRAN
+-
+-INSERT INTO KNIGHTS (IDNum, Nation, Flag, IDName, Chief)
+-VALUES (@index, @nation, @community, @strName, @strChief)
+-
+-IF @@ERROR != 0
+-  BEGIN
+-    ROLLBACK TRAN
+-    SET @nRet = 2
+-    RETURN
+-  END
+-
+-UPDATE USERDATA SET Knights = @index, Fame = 1 WHERE strUserId = @strChief	-- 1 == Chief Authority
+-
+-IF @@ERROR != 0
+-  BEGIN
+-    ROLLBACK TRAN
+-    SET @nRet = 3
+-    RETURN
+-  END
+-
+-COMMIT TRAN
+-SET @nRet = 0
+-
+-GO

--- a/src/migration/21_capitalized_variables.sql
+++ b/src/migration/21_capitalized_variables.sql
@@ -1,0 +1,378 @@
+-- Capitalizing few more instances of @KnightsIndex and @KnightsName.
+--
+-- Altered procedures:
+--   - CREATE_KNIGHTS
+--   - DELETE_CHAR
+--   - DELETE_KNIGHTS
+--   - LOAD_KNIGHTS_MEMBERS
+
+--------------------------------------------------------------------------------------------------
+-- CREATE_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER PROCEDURE [dbo].[CREATE_KNIGHTS]
+  @nRet smallint OUTPUT,
+  @index smallint,
+  @nation tinyint,
+  @community tinyint,
+  @strName char(21),
+  @strChief char(21)
+AS
+
+DECLARE @Row tinyint, @KnightsIndex smallint, @KnightsName char(21)
+SET @Row = 0 SET @KnightsIndex = 0 SET @KnightsName = ''
+
+SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @index OR IDName = @strName
+
+IF @Row > 0 OR @index = 0
+  BEGIN
+    SET @nRet = 3
+    RETURN
+  END
+
+--SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDName = @strName
+
+--IF @Row > 0
+--	BEGIN
+--	SET @nRet =  3
+--RETURN
+--	END
+
+BEGIN TRAN
+
+INSERT INTO KNIGHTS (IDNum, Nation, Flag, IDName, Chief)
+VALUES (@index, @nation, @community, @strName, @strChief)
+
+INSERT INTO KNIGHTS_USER (sIDNum, strUserID)
+VALUES (@index, @strChief)
+
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 6
+    RETURN
+  END
+
+--	UPDATE USERDATA SET Knights = @index, Fame = 1 WHERE strUserId = @strChief	-- 1 == Chief Authority
+
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 6
+    RETURN
+  END
+
+COMMIT TRAN
+SET @nRet = 0
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- DELETE_CHAR
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+ALTER PROCEDURE [dbo].[DELETE_CHAR]
+  @AccountID char(21),
+  @index tinyint,
+  @CharID char(21),
+  @SocNo char(15),
+  @nRet smallint OUTPUT
+AS
+
+DECLARE
+  @bCharNum tinyint,
+  @charid1 char(21),
+  @charid2 char(21),
+  @charid3 char(21),
+  @charid4 char(21),
+  @charid5 char(21),
+  @strSocNo char(15)
+DECLARE @KnightsIndex smallint
+SET @bCharNum = 0
+SET @KnightsIndex = 0
+
+SELECT @strSocNo = strSocNo FROM [dbo].[TB_USER] WHERE strAccountID = @AccountID
+IF @SocNo != @strSocNo
+  BEGIN
+    SET @nRet = 0
+    RETURN
+  END
+
+DECLARE
+  @Nation tinyint,
+  @Race tinyint,
+  @Class smallint,
+  @HairColor tinyint,
+  @Rank tinyint,
+  @Title tinyint,
+  @Level tinyint,
+  @Exp int,
+  @Loyalty int
+DECLARE
+  @Face tinyint,
+  @City tinyint,
+  @Knights smallint,
+  @Fame tinyint,
+  @Hp smallint,
+  @Mp smallint,
+  @Sp smallint,
+  @Strong tinyint,
+  @Sta tinyint,
+  @Dex tinyint
+DECLARE
+  @Intel tinyint,
+  @Cha tinyint,
+  @Authority tinyint,
+  @Points tinyint,
+  @Gold int,
+  @Zone tinyint,
+  @Bind smallint,
+  @PX int,
+  @PZ int,
+  @PY int,
+  @dwTime int
+DECLARE @bySkill binary(10), @byItem binary(400), @bySerial binary(400), @Members smallint
+
+BEGIN TRAN
+
+IF @index = 0
+  UPDATE ACCOUNT_CHAR SET strCharID1 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 1
+  UPDATE ACCOUNT_CHAR SET strCharID2 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 2
+  UPDATE ACCOUNT_CHAR SET strCharID3 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 3
+  UPDATE ACCOUNT_CHAR SET strCharID4 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+IF @index = 4
+  UPDATE ACCOUNT_CHAR SET strCharID5 = NULL, bCharNum = bCharNum - 1 WHERE strAccountID = @AccountID
+
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 0
+    RETURN
+  END
+
+SELECT
+  @charid1 = strCharID1,
+  @charid2 = strCharID2,
+  @charid3 = strCharID3,
+  @charid4 = strCharID4,
+  @charid5 = strCharID5
+FROM ACCOUNT_CHAR
+WHERE strAccountID = @AccountID
+-- 캐릭터가 하나도 없으면 해당 레코드를 지운다.. -> 국가선택 다시 할수 있다
+IF @charid1 IS NULL AND @charid2 IS NULL AND @charid3 IS NULL AND @charid4 IS NULL AND @charid5 IS NULL
+  BEGIN
+    DELETE FROM ACCOUNT_CHAR WHERE strAccountID = @AccountID
+    IF @@ERROR != 0
+      BEGIN
+        ROLLBACK TRAN
+        SET @nRet = 0
+        RETURN
+      END
+  END
+
+SELECT
+  @Nation = Nation,
+  @Race = Race,
+  @Class = [Class],
+  @HairColor = HairColor,
+  @Rank = Rank,
+  @Title = Title,
+  @Level = [Level],
+  @Exp = [Exp],
+  @Loyalty = Loyalty,
+  @Face = Face,
+  @City = City,
+  @Knights = Knights,
+  @Fame = Fame,
+  @Hp = Hp,
+  @Mp = Mp,
+  @Sp = Sp,
+  @Strong = Strong,
+  @Sta = Sta,
+  @Dex = Dex,
+  @Intel = Intel,
+  @Cha = Cha,
+  @Authority = Authority,
+  @Points = Points,
+  @Gold = Gold,
+  @Zone = [Zone],
+  @Bind = Bind,
+  @PX = PX,
+  @PZ = PZ,
+  @PY = PY,
+  @dwTime = dwTime,
+  @bySkill = bySkill,
+  @byItem = byItem,
+  @bySerial = bySerial
+FROM USERDATA WHERE strUserId = @CharID
+
+INSERT INTO DELETED_USERDATA (
+  strAccountID,
+  strUserId,
+  Nation,
+  Race,
+  [Class],
+  HairColor,
+  Rank,
+  Title,
+  [Level],
+  [Exp],
+  Loyalty,
+  Face,
+  City,
+  Knights,
+  Fame,
+  Hp,
+  Mp,
+  Sp,
+  Strong,
+  Sta,
+  Dex,
+  Intel,
+  Cha,
+  Authority,
+  Points,
+  Gold,
+  [Zone],
+  Bind,
+  PX,
+  PZ,
+  PY,
+  dwTime,
+  bySkill,
+  byItem,
+  bySerial
+)
+VALUES (
+  @AccountID,
+  @CharID,
+  @Nation,
+  @Race,
+  @Class,
+  @HairColor,
+  @Rank,
+  @Title,
+  @Level,
+  @Exp,
+  @Loyalty,
+  @Face,
+  @City,
+  @Knights,
+  @Fame,
+  @Hp,
+  @Mp,
+  @Sp,
+  @Strong,
+  @Sta,
+  @Dex,
+  @Intel,
+  @Cha,
+  @Authority,
+  @Points,
+  @Gold,
+  @Zone,
+  @Bind,
+  @PX,
+  @PZ,
+  @PY,
+  @dwTime,
+  @bySkill,
+  @byItem,
+  @bySerial
+)
+
+DELETE FROM USERDATA WHERE strUserId = @CharID
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 0
+    RETURN
+  END
+
+DELETE FROM KNIGHTS_USER WHERE strUserID = @CharID
+SELECT @Members = Members FROM KNIGHTS WHERE IDNum = @Knights
+IF @Members <= 1
+  UPDATE KNIGHTS SET Members = 1 WHERE IDNum = @Knights
+ELSE
+  UPDATE KNIGHTS SET Members = Members - 1 WHERE IDNum = @Knights
+
+COMMIT TRAN
+SET @nRet = 1
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- DELETE_KNIGHTS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+ALTER PROCEDURE [dbo].[DELETE_KNIGHTS]
+  @nRet smallint OUTPUT,
+  @KnightsIndex smallint
+AS
+
+DECLARE @Row tinyint, @Knights smallint, @Fame tinyint, @UserID char(21)
+SET @Row = 0 SET @Knights = 0 SET @Fame = 0 SET @UserID = ''
+
+
+
+SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @KnightsIndex
+IF @Row = 0
+  BEGIN
+    SET @nRet = 7
+    RETURN
+  END
+
+BEGIN TRAN
+
+DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
+DELETE FROM KNIGHTS_USER WHERE sIDNum = @KnightsIndex
+
+IF @@ERROR != 0
+  BEGIN
+    ROLLBACK TRAN
+    SET @nRet = 7
+    RETURN
+  END
+
+COMMIT TRAN
+SET @nRet = 0
+
+GO
+
+--------------------------------------------------------------------------------------------------
+-- LOAD_KNIGHTS_MEMBERS
+SET ANSI_NULLS OFF
+GO
+SET QUOTED_IDENTIFIER OFF
+GO
+
+-- Scripted by Sungyong
+-- 2002.09.26
+
+ALTER PROCEDURE [dbo].[LOAD_KNIGHTS_MEMBERS]
+  @KnightsIndex smallint
+AS
+
+SELECT
+  strUserId,
+  Fame,
+  [Level],
+  [Class]
+FROM USERDATA WHERE Knights = @KnightsIndex
+
+--SET @nRet = 1
+--RETURN
+
+GO

--- a/src/migration/21_capitalized_variables.sql.diff
+++ b/src/migration/21_capitalized_variables.sql.diff
@@ -1,0 +1,96 @@
+diff --git a/src/procedure/CREATE_KNIGHTS.sql b/src/procedure/CREATE_KNIGHTS.sql
+index d790cbf..cfed379 100644
+--- a/src/procedure/CREATE_KNIGHTS.sql
++++ b/src/procedure/CREATE_KNIGHTS.sql
+@@ -4,18 +4,16 @@ SET QUOTED_IDENTIFIER ON
+ GO
+ 
+ CREATE PROCEDURE [dbo].[CREATE_KNIGHTS]
+-
+   @nRet smallint OUTPUT,
+   @index smallint,
+   @nation tinyint,
+   @community tinyint,
+   @strName char(21),
+   @strChief char(21)
+-
+ AS
+ 
+-DECLARE @Row tinyint, @knightsindex smallint, @knightsname char(21)
+-SET @Row = 0 SET @knightsindex = 0 SET @knightsname = ''
++DECLARE @Row tinyint, @KnightsIndex smallint, @KnightsName char(21)
++SET @Row = 0 SET @KnightsIndex = 0 SET @KnightsName = ''
+ 
+ SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @index OR IDName = @strName
+ 
+diff --git a/src/procedure/DELETE_CHAR.sql b/src/procedure/DELETE_CHAR.sql
+index 45b8554..ed6fae9 100644
+--- a/src/procedure/DELETE_CHAR.sql
++++ b/src/procedure/DELETE_CHAR.sql
+@@ -18,9 +18,9 @@ DECLARE
+   @charid4 char(21),
+   @charid5 char(21),
+   @strSocNo char(15)
+-DECLARE @knightsindex smallint
++DECLARE @KnightsIndex smallint
+ SET @bCharNum = 0
+-SET @knightsindex = 0
++SET @KnightsIndex = 0
+ 
+ SELECT @strSocNo = strSocNo FROM [dbo].[TB_USER] WHERE strAccountID = @AccountID
+ IF @SocNo != @strSocNo
+diff --git a/src/procedure/DELETE_KNIGHTS.sql b/src/procedure/DELETE_KNIGHTS.sql
+index b61f48d..9a36017 100644
+--- a/src/procedure/DELETE_KNIGHTS.sql
++++ b/src/procedure/DELETE_KNIGHTS.sql
+@@ -6,7 +6,7 @@ GO
+ 
+ CREATE PROCEDURE [dbo].[DELETE_KNIGHTS]
+   @nRet smallint OUTPUT,
+-  @knightsindex smallint
++  @KnightsIndex smallint
+ AS
+ 
+ DECLARE @Row tinyint, @Knights smallint, @Fame tinyint, @UserID char(21)
+@@ -14,7 +14,7 @@ SET @Row = 0 SET @Knights = 0 SET @Fame = 0 SET @UserID = ''
+ 
+ 
+ 
+-SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @knightsindex
++SELECT @Row = COUNT(*) FROM KNIGHTS WHERE IDNum = @KnightsIndex
+ IF @Row = 0
+   BEGIN
+     SET @nRet = 7
+@@ -23,8 +23,8 @@ IF @Row = 0
+ 
+ BEGIN TRAN
+ 
+-DELETE FROM KNIGHTS WHERE IDNum = @knightsindex
+-DELETE FROM KNIGHTS_USER WHERE sIDNum = @knightsindex
++DELETE FROM KNIGHTS WHERE IDNum = @KnightsIndex
++DELETE FROM KNIGHTS_USER WHERE sIDNum = @KnightsIndex
+ 
+ IF @@ERROR != 0
+   BEGIN
+diff --git a/src/procedure/LOAD_KNIGHTS_MEMBERS.sql b/src/procedure/LOAD_KNIGHTS_MEMBERS.sql
+index c6ccd7c..4c7695f 100644
+--- a/src/procedure/LOAD_KNIGHTS_MEMBERS.sql
++++ b/src/procedure/LOAD_KNIGHTS_MEMBERS.sql
+@@ -7,7 +7,7 @@ GO
+ -- 2002.09.26
+ 
+ CREATE PROCEDURE [dbo].[LOAD_KNIGHTS_MEMBERS]
+-  @knightsindex smallint
++  @KnightsIndex smallint
+ AS
+ 
+ SELECT
+@@ -15,7 +15,7 @@ SELECT
+   Fame,
+   [Level],
+   [Class]
+-FROM USERDATA WHERE Knights = @knightsindex
++FROM USERDATA WHERE Knights = @KnightsIndex
+ 
+ --SET @nRet = 1
+ --RETURN


### PR DESCRIPTION
### Description

Note that this PR resolves also the following issue: https://github.com/ko4life-net/ko/issues/223

There are so many more inconsistencies in the scripts that I'll fix on separate PRs.
Note that I also need to update the import script to automatically create the db with default Latin1 collation:
```sql
CREATE DATABASE [$db_name] COLLATE SQL_Latin1_General_CP1_CI_AS;
```

But I'll do that after merging and creating a small hot-fix release out of this, otherwise the initial import of the script won't work with case-sensitive collation.