### PR TITLE
Enforce SQL_Latin1_General_CP1_CS_AS collation on db creation.

### DIFF
--- a/import.ps1
+++ b/import.ps1
@@ -76,7 +76,7 @@ function RecreateDb {
   }
 
   MessageInfo "Creating database $db_name..."
-  InvokeSqlQuery -query "USE master; CREATE DATABASE [$db_name];"
+  InvokeSqlQuery -query "USE master; CREATE DATABASE [$db_name] COLLATE SQL_Latin1_General_CP1_CS_AS;"
 }
 
 function RunInitialDbScripts {


### PR DESCRIPTION
### Description

This PR enforces SQL_Latin1_General_CP1_CS_AS  collation on db creation, just to reduce the likelihood of users experiencing odd issues as can be seen in the following ticket: https://github.com/ko4life-net/ko/issues/223

Additionally we enforce `CS` for case-sensitivity to encourage consistency.