### PR TITLE
Simplify scripts to use powershell switch args over booleans.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Check lint
         run: |
-          & .\format.ps1 -verbose_output $true
+          & .\format.ps1 -verbose_output
           $git_diff = (git diff --stat -- "*.sql")
           if ($git_diff -ne $null) {
               Write-Host "Code formatting issues found! Please run the format.ps1 script, commit the changes and push."

--- a/export.ps1
+++ b/export.ps1
@@ -6,18 +6,20 @@
 param (
     # change server_name if you installed your sql server as a Named Instance.
     # If you installed on the Default Instance, then you can leave this as-is.
+    # If you're still not sure what is your sql server names, you can run the following powershell command:
+    # (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server').InstalledInstances
     [string][Parameter(Mandatory = $false)]
     $server_name = "localhost",
 
     [string][Parameter(Mandatory = $false)]
     $db_name = "kodb",
 
+    # skip code formatting and linting
+    [switch][Parameter(Mandatory = $false)]
+    $skip_format,
 
-    [bool][Parameter(Mandatory = $false)]
-    $apply_format = $true,
-
-    [bool][Parameter(Mandatory = $false)]
-    $quiet = $false
+    [switch][Parameter(Mandatory = $false)]
+    $quiet
 )
 
 . "$PSScriptRoot\logger.ps1"
@@ -95,7 +97,7 @@ function Main {
 
   Remove-Item tmp -Recurse
 
-  if ($apply_format) {
+  if (-not $skip_format) {
     # Note that we intentionally don't format schema and data, because they're not written
     # by the user and also because it takes a while to format big data.
     sqlfluff format `

--- a/format.ps1
+++ b/format.ps1
@@ -1,7 +1,7 @@
 # Check the .sqlfluff config file for more info
 param (
-    [bool][Parameter(Mandatory = $false)]
-    $verbose_output = $false
+    [switch][Parameter(Mandatory = $false)]
+    $verbose_output
 )
 
 $dirs_to_format = @(

--- a/import.ps1
+++ b/import.ps1
@@ -123,7 +123,7 @@ function RunMigrationScriptsAndGenerateDiffs {
     git commit -m $tempUniqueCommitMessage
   }
   # Note that we're intentionally doing it this way, to be sure that we're not deleting commits we shouldn't
-  $commits = git rev-list --grep="$tempUniqueCommitMessage" --reverse HEAD
+  $commits = @(git rev-list --grep="$tempUniqueCommitMessage" --reverse HEAD)
   if ($commits.Count) {
     git reset --hard "$($commits[0])^1"
   }

--- a/src/migration/README.md
+++ b/src/migration/README.md
@@ -5,7 +5,7 @@ Add here scripts that alters the existing database's schema, procedures, data an
 Couple of rules and notes when writing migration scripts:
 - Always assume the database containing data, even if you just modify an empty table
 - When altering the schema, adding comments (`--` for tsql) are encouraged
-- When submitting a PR, please generate a `*.diff` file and commit it (`.\import.ps1 -generate_diffs $true`)
+- When submitting a PR, please generate a `*.diff` file and commit it (`.\import.ps1 -generate_diffs`)
 - Every migration script should start with max 4 leading zeros (example `0001_insert_user.sql`)
 
 ## Creating a new release
@@ -16,7 +16,7 @@ Below are instructions for the release engineer in order to create a new db rele
 - Run the export script, to be sure that no diff is produced (`.\export.ps1` and then `git status`)
   - If there are local changes, something is probably off. Repeat the steps above
   - If you're sure all in order, best is if you create a new separate PR with the changes, in case empty spaces and such were added
-- Run the import script again with the migration scripts and produce diffs (`.\import.ps1 -generate_diffs $true`)
+- Run the import script again with the migration scripts and produce diffs (`.\import.ps1 -generate_diffs`)
 - Move all migration scripts and its `*.diff` files to the `archived` directory
 - Lastly run the export script once more, but this time you'll have the actual changes from the migration scripts affecting the actual schema
 - Git commit all the changes (`Bump version from 1.0.0 to 1.0.1.`)


### PR DESCRIPTION
### Description

Simplify scripts to use powershell switch args over booleans.

Additionally I also fixed an issue with the import script when generating rev-list to always return a list, even if only 1 migration script is running.
